### PR TITLE
Add new include-public option for single-category operations

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -27,13 +27,13 @@ program
   .option('-r, --rate-limit <time>', 'time interval for network requests in ms (default is 20)')
   .parse(process.argv);
 
-const backupDir    = program.backupDir;
-const category     = program.category || '';
-const authScope    = category.length > 0 ? category+':rw' : '*:rw';
-const rateLimit    = program.rateLimit || 20;
-var userAddress    = program.userAddress;
-var token          = program.token;
-var storageBaseUrl = null;
+const backupDir     = program.backupDir;
+const category      = program.category || '';
+const authScope     = category.length > 0 ? category+':rw' : '*:rw';
+const rateLimit     = program.rateLimit || 20;
+let userAddress     = program.userAddress;
+let token           = program.token;
+let storageBaseUrl  = null;
 
 if (!(backupDir)) {
   // TODO ask or use default
@@ -41,14 +41,19 @@ if (!(backupDir)) {
   process.exit(1);
 }
 
-let isDirectory = function(str) {
+const isDirectory = function(str) {
   return str[str.length-1] === '/';
 };
 
-let initialDir = isDirectory(category) || category === '' ? category : category+'/';
+const initialDir = isDirectory(category) || category === '' ? category : category+'/';
 
-var fetchDocument = function(path) {
-  let options = {
+const handleError = function(error) {
+  console.log(colors.red(error.message));
+  process.exit(1);
+};
+
+const fetchDocument = function(path) {
+  const options = {
     headers: { "Authorization": `Bearer ${token}`, "User-Agent": "RSBackup/1.0" }
   };
   return fetch(storageBaseUrl+encodePath(path), options)
@@ -67,12 +72,12 @@ var fetchDocument = function(path) {
     .catch(error => handleError(error));
 };
 
-let fetchDocumentRateLimited = rateLimited(fetchDocument, rateLimit);
+const fetchDocumentRateLimited = rateLimited(fetchDocument, rateLimit);
 
-var fetchDirectoryContents = function(dir) {
+const fetchDirectoryContents = function(dir) {
   mkdirp.sync(backupDir+'/'+dir);
 
-  let options = {
+  const options = {
     headers: { "Authorization": `Bearer ${token}`, "User-Agent": "RSBackup/1.0" }
   };
   return fetch(storageBaseUrl+encodePath(dir), options)
@@ -101,14 +106,9 @@ var fetchDirectoryContents = function(dir) {
     .catch(error => handleError(error));
 };
 
-let fetchDirectoryContentsRateLimited = rateLimited(fetchDirectoryContents, rateLimit);
+const fetchDirectoryContentsRateLimited = rateLimited(fetchDirectoryContents, rateLimit);
 
-var handleError = function(error) {
-  console.log(colors.red(error.message));
-  process.exit(1);
-};
-
-var lookupStorageInfo = function() {
+const lookupStorageInfo = function() {
   return discovery.lookup(userAddress).then(storageInfo => {
     let href = storageInfo.href;
     if (href[href.length-1] !== '/') { href = href+'/'; }
@@ -121,14 +121,14 @@ var lookupStorageInfo = function() {
   });
 };
 
-var executeBackup = function() {
+const executeBackup = function() {
   console.log('Starting backup...\n');
   rimraf.sync(backupDir); // TODO incremental update
   mkdirp.sync(backupDir);
   fetchDirectoryContents(initialDir);
 };
 
-var schemas = {
+const schemas = {
   userAddress: {
     name: 'userAddress',
     description: 'User address (user@host):',
@@ -160,7 +160,7 @@ if (token && userAddress) {
     userAddress = result.userAddress;
 
     lookupStorageInfo().then(storageInfo => {
-      let authURL = addQueryParamsToURL(storageInfo.authURL, {
+      const authURL = addQueryParamsToURL(storageInfo.authURL, {
         client_id: 'rs-backup.5apps.com',
         redirect_uri: 'https://rs-backup.5apps.com/',
         response_type: 'token',

--- a/backup.js
+++ b/backup.js
@@ -21,14 +21,16 @@ const addQueryParamsToURL = require('./add-query-params-to-url');
 program
   .version(pkg.version)
   .option('-o, --backup-dir <path>', 'backup directory path')
-  .option('-c, --category <category>', 'category (base directory) to back up')
   .option('-u, --user-address <user address>', 'user address (user@host)')
   .option('-t, --token <token>', 'valid bearer token')
+  .option('-c, --category <category>', 'category (base directory) to back up')
+  .option('-p, --include-public', 'when backing up a single category, include the public folder of that category')
   .option('-r, --rate-limit <time>', 'time interval for network requests in ms (default is 20)')
   .parse(process.argv);
 
 const backupDir     = program.backupDir;
 const category      = program.category || '';
+const includePublic = program.includePublic || false;
 const authScope     = category.length > 0 ? category+':rw' : '*:rw';
 const rateLimit     = program.rateLimit || 20;
 let userAddress     = program.userAddress;
@@ -46,6 +48,11 @@ const isDirectory = function(str) {
 };
 
 const initialDir = isDirectory(category) || category === '' ? category : category+'/';
+
+let publicDir = null;
+if (category !== '') {
+  publicDir = `public/${initialDir}`;
+}
 
 const handleError = function(error) {
   console.log(colors.red(error.message));
@@ -126,6 +133,9 @@ const executeBackup = function() {
   rimraf.sync(backupDir); // TODO incremental update
   mkdirp.sync(backupDir);
   fetchDirectoryContents(initialDir);
+  if (includePublic && publicDir) {
+    fetchDirectoryContents(publicDir);
+  }
 };
 
 const schemas = {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.7.1",
   "description": "Backup and restore data from/to a remoteStorage account",
   "keywords": [
-    "remotestorage",
-    "rs"
+    "remotestorage"
   ],
   "bin": {
     "rs-backup": "./backup.js",
@@ -18,10 +17,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/skddc/rs-backup.git"
+    "url": "https://github.com/raucao/rs-backup.git"
   },
   "bugs": {
-    "url": "https://github.com/skddc/rs-backup/issues"
+    "url": "https://github.com/raucao/rs-backup/issues"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Exactly as stated in the `--help` text for `--include-public`:

> when backing up a single category, include the public folder of that category