### PR TITLE
Sends Origin header matching redirect URL

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -28,6 +28,7 @@ program
   .option('-r, --rate-limit <time>', 'time interval for network requests in ms (default is 20)')
   .parse(process.argv);
 
+const ORIGIN = 'https://rs-backup.5apps.com';
 const backupDir     = program.backupDir;
 const category      = program.category || '';
 const includePublic = program.includePublic || false;
@@ -67,7 +68,7 @@ const fetchDocument = function(path) {
   _retryMap[path] = _retryMap[path] || 0;
 
   const options = {
-    headers: { "Authorization": `Bearer ${token}`, "User-Agent": `RSBackup/${program._version}` }
+    headers: { "Authorization": `Bearer ${token}`, "User-Agent": `RSBackup/${program._version}`, "Origin": ORIGIN }
   };
   return fetch(storageBaseUrl+encodePath(path), options)
     .then(res => {
@@ -108,7 +109,7 @@ const fetchDirectoryContents = function(dir) {
   mkdirp.sync(backupDir+'/'+dir);
 
   const options = {
-    headers: { "Authorization": `Bearer ${token}`, "User-Agent": "RSBackup/1.0" }
+    headers: { "Authorization": `Bearer ${token}`, "User-Agent": `RSBackup/${program._version}`, "Origin": ORIGIN }
   };
   return fetch(storageBaseUrl+encodePath(dir), options)
     .then(res => {
@@ -210,7 +211,7 @@ if (token && userAddress) {
     lookupStorageInfo().then(storageInfo => {
       const authURL = addQueryParamsToURL(storageInfo.authURL, {
         client_id: 'rs-backup.5apps.com',
-        redirect_uri: 'https://rs-backup.5apps.com/',
+        redirect_uri: ORIGIN + '/',
         response_type: 'token',
         scope: authScope
       });

--- a/restore.js
+++ b/restore.js
@@ -25,6 +25,7 @@ program
   .option('-r, --rate-limit <time>', 'time interval for network requests in ms (default is 40)')
   .parse(process.argv);
 
+const ORIGIN = 'https://rs-backup.5apps.com';
 const backupDir     = program.backupDir;
 const category      = program.category || '';
 const includePublic = program.includePublic || false;
@@ -60,7 +61,8 @@ const putDocument = function(path, meta) {
     'Authorization': `Bearer ${token}`,
     'Content-Type': meta['Content-Type'],
     'If-None-Match': '"'+meta['ETag']+'"',
-    'User-Agent': "RSBackup/1.0"
+    'User-Agent': "RSBackup/1.0",
+    'Origin': ORIGIN
   };
 
   let body;
@@ -164,7 +166,7 @@ if (token && userAddress) {
     lookupStorageInfo().then(storageInfo => {
       const authURL = addQueryParamsToURL(storageInfo.authURL, {
         client_id: 'rs-backup.5apps.com',
-        redirect_uri: 'https://rs-backup.5apps.com/',
+        redirect_uri: ORIGIN + '/',
         response_type: 'token',
         scope: authScope
       });


### PR DESCRIPTION
OAuth tokens should be specific to the origin of a web app.  So, an RS server may require that the Origin of a request match the redirect URI used when obtaining the OAuth token.  This PR supports that, by sending the Origin header, like a webapp does.